### PR TITLE
Updates to accommodate ExecuteReader updates 

### DIFF
--- a/src/Gemstone.Timeseries/MeasurementKey.cs
+++ b/src/Gemstone.Timeseries/MeasurementKey.cs
@@ -26,6 +26,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.Data;
+using System.Data.Common;
 using System.Threading;
 using Gemstone.Data.DataExtensions;
 using Gemstone.StringExtensions;
@@ -459,7 +460,7 @@ public class MeasurementKey
     ///      SignalID    GUID        Unique identification for measurement
     /// </code>
     /// </remarks>
-    public static void EstablishDefaultCache(IDbConnection connection, string measurementTable = "ActiveMeasurement")
+    public static void EstablishDefaultCache(DbConnection connection, string measurementTable = "ActiveMeasurement")
     {
         // Establish default measurement key cache
         foreach (DataRow measurement in connection.RetrieveData($"SELECT ID, SignalID FROM {measurementTable}").Rows)

--- a/src/Gemstone.Timeseries/TimeSeriesStartupOperations.cs
+++ b/src/Gemstone.Timeseries/TimeSeriesStartupOperations.cs
@@ -26,6 +26,7 @@
 using System;
 using System.Collections.Generic;
 using System.Data;
+using System.Data.Common;
 using Gemstone.Data;
 using Gemstone.Data.DataExtensions;
 using Gemstone.Identity;
@@ -169,7 +170,10 @@ public static class TimeseriesStartupOperations
         Dictionary<string, string> updateMap = new();
 
         // Find user accounts that need to be updated
-        using (IDataReader userAccountReader = database.Connection.ExecuteReader(SelectUserAccountQuery))
+        (DbDataReader userAccountReader, DbCommand command) = database.Connection.ExecuteReader(SelectUserAccountQuery);
+
+        using (userAccountReader)
+        using (command)
         {
             while (userAccountReader.Read())
             {
@@ -193,7 +197,10 @@ public static class TimeseriesStartupOperations
         updateMap.Clear();
 
         // Find security groups that need to be updated
-        using (IDataReader securityGroupReader = database.Connection.ExecuteReader(SelectSecurityGroupQuery))
+        (DbDataReader securityGroupReader, command) = database.Connection.ExecuteReader(SelectSecurityGroupQuery);
+
+        using (securityGroupReader)
+        using (command)
         {
             while (securityGroupReader.Read())
             {


### PR DESCRIPTION
Async updates to Gemstone return the "command" instance to `ExecuteReader` operations which are called from a connection instance such that command can be explicitly disposed instead leaving junk to be collected by GC. 